### PR TITLE
Small Typo Fix

### DIFF
--- a/src/components/download/options.js
+++ b/src/components/download/options.js
@@ -15,7 +15,7 @@ export default class Options extends Component {
     return (
       <div className="options container">
         <h2>Choose your technologies</h2>
-        <p>{`Choose your technologies here by clicking on the one you want. You'll be able to download the generated see project when you have selected one of each.`}</p>
+        <p>{`Choose your technologies here by clicking on the one you want. You'll be able to download the generated seed project when you have selected one of each.`}</p>
         <p>Fountain lets you choose among all the most popular technologies both for your development framework and your tooling.</p>
         <p>These choices are very structurant so choose them carefully but freely: Fountain will be able to generate a fully configured and working project whatever the options you choose.</p>
         {options.map((option, i) => <Option key={i} option={i} selected={selection[i]} select={select} {...option}/>)}


### PR DESCRIPTION
`see` -> `seed` in the documentation page